### PR TITLE
mutiple fixes and two features: comments=documentation in the generated lexer + 'backtracking' lexer power

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules/
+
+# Editor bak files
+*~
+*.bak
+*.orig

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -159,7 +159,7 @@ RegExpLexer.prototype = {
     // resets the lexer, sets new input
     setInput: function (input) {
         this._input = input;
-        this._more = this.done = false;
+        this._more = this._backtrack = this.done = false;
         this.yylineno = this.yyleng = 0;
         this.yytext = this.matched = this.match = '';
         this.conditionStack = ['INITIAL'];
@@ -296,11 +296,17 @@ RegExpLexer.prototype = {
         }
         if (match) {
             lines = match[0].match(/(?:\r\n?|\n).*/g);
-            if (lines) this.yylineno += lines.length;
-            this.yylloc = {first_line: this.yylloc.last_line,
-                           last_line: this.yylineno+1,
-                           first_column: this.yylloc.last_column,
-                           last_column: lines ? lines[lines.length-1].length-lines[lines.length-1].match(/\r?\n?/)[0].length : this.yylloc.last_column + match[0].length};
+	        if (lines) {
+	            this.yylineno += lines.length;
+			}
+	        this.yylloc = {
+	            first_line: this.yylloc.last_line,
+	            last_line: this.yylineno + 1,
+	            first_column: this.yylloc.last_column,
+	            last_column: lines ?
+	                         lines[lines.length - 1].length - lines[lines.length - 1].match(/\r?\n?/)[0].length :
+	                         this.yylloc.last_column + match[0].length
+	        };
             this.yytext += match[0];
             this.match += match[0];
             this.matches = match;
@@ -312,7 +318,9 @@ RegExpLexer.prototype = {
             this._input = this._input.slice(match[0].length);
             this.matched += match[0];
             token = this.performAction.call(this, this.yy, this, rules[index],this.conditionStack[this.conditionStack.length-1]);
-            if (this.done && this._input) this.done = false;
+	        if (this.done && this._input) {
+	            this.done = false;
+	        }
             if (token) return token;
             else return;
         }

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -164,14 +164,14 @@ RegExpLexer.prototype = {
         this.yytext = this.matched = this.match = '';
         this.conditionStack = ['INITIAL'];
         this.yylloc = {
-			first_line: 1,
-			first_column: 0,
-			last_line: 1,
-			last_column: 0
-		};
+            first_line: 1,
+            first_column: 0,
+            last_line: 1,
+            last_column: 0
+        };
         if (this.options.ranges) {
-			this.yylloc.range = [0,0];
-		}
+            this.yylloc.range = [0,0];
+        }
         this.offset = 0;
         return this;
     },
@@ -192,8 +192,8 @@ RegExpLexer.prototype = {
             this.yylloc.last_column++;
         }
         if (this.options.ranges) {
-			this.yylloc.range[1]++;
-		}
+            this.yylloc.range[1]++;
+        }
 
         this._input = this._input.slice(1);
         return ch;
@@ -213,17 +213,17 @@ RegExpLexer.prototype = {
         this.matched = this.matched.substr(0, this.matched.length - 1);
 
         if (lines.length - 1) {
-			this.yylineno -= lines.length - 1;
-		}
+            this.yylineno -= lines.length - 1;
+        }
         var r = this.yylloc.range;
 
         this.yylloc = {
-			first_line: this.yylloc.first_line,
-          	last_line: this.yylineno + 1,
-	        first_column: this.yylloc.first_column,
+            first_line: this.yylloc.first_line,
+            last_line: this.yylineno + 1,
+            first_column: this.yylloc.first_column,
             last_column: lines ?
-              	(lines.length === oldLines.length ? this.yylloc.first_column : 0)
-				 + oldLines[oldLines.length - lines.length].length - lines[0].length :
+                (lines.length === oldLines.length ? this.yylloc.first_column : 0)
+                 + oldLines[oldLines.length - lines.length].length - lines[0].length :
               this.yylloc.first_column - len
         };
 
@@ -318,7 +318,7 @@ RegExpLexer.prototype = {
         lines = match[0].match(/(?:\r\n?|\n).*/g);
         if (lines) {
             this.yylineno += lines.length;
-		}
+        }
         this.yylloc = {
             first_line: this.yylloc.last_line,
             last_line: this.yylineno + 1,
@@ -433,7 +433,7 @@ RegExpLexer.prototype = {
         this.conditionStack.push(condition);
     },
 
-	// pop the previously active lexer condition state off the condition stack
+    // pop the previously active lexer condition state off the condition stack
     popState: function popState () {
         var n = this.conditionStack.length - 1;
         if (n > 0) {
@@ -443,26 +443,26 @@ RegExpLexer.prototype = {
         }
     },
 
-	// produce the lexer rule set which is active for the currently active lexer condition state
+    // produce the lexer rule set which is active for the currently active lexer condition state
     _currentRules: function _currentRules () {
-		if (this.conditionStack.length && this.conditionStack[this.conditionStack.length - 1]) {
-	        return this.conditions[this.conditionStack[this.conditionStack.length - 1]].rules;
-		} else {
-	        return this.conditions["INITIAL"].rules;
-		}
+        if (this.conditionStack.length && this.conditionStack[this.conditionStack.length - 1]) {
+            return this.conditions[this.conditionStack[this.conditionStack.length - 1]].rules;
+        } else {
+            return this.conditions["INITIAL"].rules;
+        }
     },
 
- 	// return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available
+    // return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available
     topState: function topState (n) {
-		n = this.conditionStack.length - 1 - Math.abs(n || 0);
-		if (n >= 0) {
-	        return this.conditionStack[n];
-		} else {
-			return "INITIAL";
-		}
+        n = this.conditionStack.length - 1 - Math.abs(n || 0);
+        if (n >= 0) {
+            return this.conditionStack[n];
+        } else {
+            return "INITIAL";
+        }
     },
 
-	// alias for begin(condition)
+    // alias for begin(condition)
     pushState: function pushState (condition) {
         this.begin(condition);
     },
@@ -490,18 +490,18 @@ RegExpLexer.prototype = {
             pastInput: "displays already matched input, i.e. for error messages",
             upcomingInput: "displays upcoming input, i.e. for error messages",
             showPosition: "displays the character position where the lexing error occurred, i.e. for error messages",
-			test_match: "test the lexed token: return FALSE when not a match, otherwise return token",
+            test_match: "test the lexed token: return FALSE when not a match, otherwise return token",
             next: "return next match in input",
             lex: "return next match that has a token",
-		    begin: "activates a new lexer condition state (pushes the new lexer condition state onto the condition stack)",
-			popState: "pop the previously active lexer condition state off the condition stack",
-			_currentRules: "produce the lexer rule set which is active for the currently active lexer condition state",
-		    topState: "return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available",
-		    pushState: "alias for begin(condition)"
+            begin: "activates a new lexer condition state (pushes the new lexer condition state onto the condition stack)",
+            popState: "pop the previously active lexer condition state off the condition stack",
+            _currentRules: "produce the lexer rule set which is active for the currently active lexer condition state",
+            topState: "return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available",
+            pushState: "alias for begin(condition)"
         };
         var out = "{\n";
         var p = [];
-		var descr;
+        var descr;
         for (var k in RegExpLexer.prototype) {
             if (RegExpLexer.prototype.hasOwnProperty(k) && k.indexOf("generate") === -1) {
                 // copy the function description as a comment before the implementation; supports multi-line descriptions

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -230,6 +230,7 @@ RegExpLexer.prototype = {
         if (this.options.ranges) {
             this.yylloc.range = [r[0], r[0] + this.yyleng - len];
         }
+        this.yyleng = this.yytext.length;
         return this;
     },
 

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -159,7 +159,7 @@ RegExpLexer.prototype = {
     // resets the lexer, sets new input
     setInput: function (input) {
         this._input = input;
-        this._more = this._less = this.done = false;
+        this._more = this.done = false;
         this.yylineno = this.yyleng = 0;
         this.yytext = this.matched = this.match = '';
         this.conditionStack = ['INITIAL'];

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -111,8 +111,8 @@ function buildActions (dict, tokens) {
 
     this.rules = prepareRules(dict.rules, dict.macros, actions, tokens && toks, this.conditions, this.options["case-insensitive"]);
     var fun = actions.join("\n");
-    "yytext yyleng yylineno".split(' ').forEach(function (yy) {
-        fun = fun.replace(new RegExp("("+yy+")", "g"), "yy_.$1");
+    "yytext yyleng yylineno yylloc".split(' ').forEach(function (yy) {
+        fun = fun.replace(new RegExp("\\b("+yy+")\\b", "g"), "yy_.$1");
     });
 
     return Function("yy,yy_,$avoiding_name_collisions,YY_START", fun);

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -115,7 +115,14 @@ function buildActions (dict, tokens) {
         fun = fun.replace(new RegExp("\\b("+yy+")\\b", "g"), "yy_.$1");
     });
 
-    return Function("yy,yy_,$avoiding_name_collisions,YY_START", fun);
+
+    // first try to create the performAction function the old way,
+    // but this will break for some legal constructs in the user action code:
+    try {
+        return Function("yy,yy_,$avoiding_name_collisions,YY_START", fun);
+    } catch (e) {
+        return "function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {" + fun + "\n}";
+    }
 }
 
 function RegExpLexer (dict, input, tokens) {

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -467,6 +467,11 @@ RegExpLexer.prototype = {
         this.begin(condition);
     },
 
+    // return the number of states pushed
+    stateStackSize: function stateStackSize() {
+        return this.conditionStack.length;
+    },
+
     generate:  function generate(opt) {
         var code = "";
         if (opt.moduleType === 'commonjs') {
@@ -497,7 +502,8 @@ RegExpLexer.prototype = {
             popState: "pop the previously active lexer condition state off the condition stack",
             _currentRules: "produce the lexer rule set which is active for the currently active lexer condition state",
             topState: "return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available",
-            pushState: "alias for begin(condition)"
+            pushState: "alias for begin(condition)",
+            stateStackSize: "return the number of states currently on the stack"
         };
         var out = "{\n";
         var p = [];

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -58,7 +58,7 @@ function prepareRules(rules, macros, actions, tokens, startConditions, caseless)
         }
         action = rules[i][1];
         if (tokens && action.match(/return '[^']+'/)) {
-            action = action.replace(/return '([^']+)'/, tokenNumberReplacement);
+            action = action.replace(/return '([^']+)'/g, tokenNumberReplacement);
         }
         actions.push('case '+i+':' +action+'\nbreak;');
     }
@@ -149,7 +149,7 @@ RegExpLexer.prototype = {
         }
     },
 
-    // resets the lexer, sets new input 
+    // resets the lexer, sets new input
     setInput: function (input) {
         this._input = input;
         this._more = this._less = this.done = false;

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -286,7 +286,7 @@ RegExpLexer.prototype = {
             this.match = '';
         }
         var rules = this._currentRules();
-        for (var i=0;i < rules.length; i++) {
+        for (var i = 0; i < rules.length; i++) {
             tempMatch = this._input.match(this.rules[rules[i]]);
             if (tempMatch && (!match || tempMatch[0].length > match[0].length)) {
                 match = tempMatch;
@@ -344,17 +344,31 @@ RegExpLexer.prototype = {
 
 	// pop the previously active lexer condition state off the condition stack
     popState: function popState () {
-        return this.conditionStack.pop();
+        var n = this.conditionStack.length - 1;
+        if (n > 0) {
+            return this.conditionStack.pop();
+        } else {
+            return this.conditionStack[0];
+        }
     },
 
 	// produce the lexer rule set which is active for the currently active lexer condition state
     _currentRules: function _currentRules () {
-        return this.conditions[this.conditionStack[this.conditionStack.length-1]].rules;
+		if (this.conditionStack.length && this.conditionStack[this.conditionStack.length - 1]) {
+	        return this.conditions[this.conditionStack[this.conditionStack.length - 1]].rules;
+		} else {
+	        return this.conditions["INITIAL"].rules;
+		}
     },
 
  	// return the currently active lexer condition state; when an index argument is provided it produces the N-th previous condition state, if available
-    topState: function () {
-        return this.conditionStack[this.conditionStack.length-2];
+    topState: function topState (n) {
+		n = this.conditionStack.length - 1 - Math.abs(n || 0);
+		if (n >= 0) {
+	        return this.conditionStack[n];
+		} else {
+			return "INITIAL";
+		}
     },
 
 	// alias for begin(condition)

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -1,4 +1,4 @@
 exports.testRegExpLexer = require("./regexplexer");
 
 if (require.main === module)
-    process.exit(require("test").run(exports)); 
+    process.exit(require("test").run(exports));

--- a/tests/regexplexer.js
+++ b/tests/regexplexer.js
@@ -54,7 +54,7 @@ exports["test unrecognized char"] = function() {
 
     var lexer = new RegExpLexer(dict, input);
     assert.equal(lexer.lex(), "X");
-    assert["throws"](function(){lexer.lex()}, "bad char");
+    assert.throws(function(){lexer.lex()}, "bad char");
 };
 
 exports["test macro"] = function() {
@@ -920,5 +920,45 @@ exports["test unput location again"] = function() {
                                     last_column: 1,
                                     range: [7, 8]});
 
+};
+
+exports["test backtracking lexer reject() method"] = function() {
+    var dict = {
+        rules: [
+            ["[A-Z]+([0-9]+)", "if (this.matches[1].length) this.reject(); else return 'ID';" ],
+            ["[A-Z]+", "return 'WORD';" ],
+            ["[0-9]+", "return 'NUM';" ]
+        ],
+        options: {backtrack_lexer: true}
+    };
+    var input = "A5";
+
+    var lexer = new RegExpLexer(dict);
+    lexer.setInput(input);
+
+    assert.equal(lexer.lex(), "WORD");
+    assert.equal(lexer.lex(), "NUM");
+};
+
+exports["test lexer reject() exception when not in backtracking mode"] = function() {
+    var dict = {
+        rules: [
+            ["[A-Z]+([0-9]+)", "if (this.matches[1].length) this.reject(); else return 'ID';" ],
+            ["[A-Z]+", "return 'WORD';" ],
+            ["[0-9]+", "return 'NUM';" ]
+        ],
+        options: {backtrack_lexer: false}
+    };
+    var input = "A5";
+
+    var lexer = new RegExpLexer(dict);
+    lexer.setInput(input);
+
+    assert.throws(function() {
+      lexer.lex();
+    },
+    function(err) {
+      return (err instanceof Error) && /You can only invoke reject/.test(err);
+    });
 };
 


### PR DESCRIPTION
# Management summary:
## Fixes:
- do the right thing when lexer action code contains multiple return statements: convert each token to its numeric value, not just the first occurrence.
- treat yylloc like you do yytext, yyleng et al: auto-expand to a `yy.` reference
- anything a little complicated in the lexer action code breaks the `Function()` construct (at least in Chrome/Chromium): fixed by providing an alternative way of constructing lexer action code from the user-defined %{...%} lexer action snippets.
- robust pushState()/popState() code
- fix inspired by code from another jison clone, which fixes the topState() error (wrong state returned)
## Features:
- add basic documentation to the lexer AND make sure that documentation ends up in the generated lexer as well; people who don't want that will/should run a minifier/obfuscator on the generated code anyway.
- options.backtrack_lexer: the lexer includes a mode to 'backtrack' i.e. try multiple matching regexes on an input each time a token is required: when the user invokes `lexer.reject();` in the %{...%} lexer action code, the current match is rejected and the subsequent regexes are tested in order to produce a desired token. If you don't use this feature, there is no extra cost.

The intent of the whole shebang is to produce a more powerful 'off the shelf' lexer which is easy/easier to debug (breaking statements across multiple lines helps debugging in Chrome a lot as you now actually see where you really are; the time of 80*25 VTs is far behind us so legibility criteria should adapt too).

(P.S.: I'm a fruitcake who pulls his generated parsers through a custom AWK script and jsbeautify to make sure the jison output is very legible and debuggable; that has saved quite some time on debugging the complex grammars. For production, one pulls the entire kaboodle through a minifier/obfuscator anyway, so I'd rather have my generated parsers be a bit verbose, particularly in the comment 'documentation' department.)
# The detailed change list

SHA-1: aa1c979
- fix: ensure that ALL tokens are converted to their numeric ID in the lexer actions. Of course the lexer MAY return strings but it is cleaner and faster to return numeric IDs every time.

This resolves the lexer output oddness for larger lexer action blocks where multiple 'return' statements can be placed in conditional sections inside the action block. for example (simplified):

```
([A-Za-z0-9_][A-Za-z0-9_]*         %{
    console.log("looking up row/column/named identifier token in symbol table: ", yytext, this, this.matches);
    s = yytext.toUpperCase();
    if (yy.symbolTable[s]) {
        rv = yy.symbolTable[s];
        yytext = {
            text: yytext,
            col: function() {
                throw new Exception("I'll be buggered!");
            }
        };
        return rv.token;
    }

    // Would it be a viable basic column identifier?
    match = s.match(/^[A-Z]+$/);
    if (match) {
        // check if this is a legal column id:
        return 'COLUMN_ID';
    }
    // Would it be a viable basic row identifier?
    match = s.match(/^[0-9]+$/);
    if (match) {
        return 'ROW_ID';
    }
    return 'error';
%}
```

SHA-1: 640dd9b
- yylloc is now expanded by the lexer, just like yytext, yylineno and yyleng already were. (yylloc --> yy.yylloc)

SHA-1: 34b6474
- and the same 'barf hairball on good action code' problem in the lexer, fixed now. Unfortunately it also means that erroneous generated action code is only detected when you try to run the generated parser.
  (I ran into the issue that jison is very whitespace sensitive: the lexer b0rked because a line separating two lexer rules contained a series of spaces and jison then decided that the second rule was simply some more action code of the first :-( )

SHA-1: 47206a3
- patched the code generator as it broke on the offending line (where the action code is poured into a Function()) for action blocks such as this one:

```
    ... rule ...
    | TAN '(' e ')'
        {
            $$ = {
                token:      FKW_FUNCTION,
                token_attr: FKA_ABSOLUTE,
                childs:     [null, $3],
                loc_info:   @$,
                type:       FT_NUMBER,
                unit:       $3.unit,
                value:      Math.abs($3.value)
            };
        }
```

The object creation like that would produce a 'Unexpected symbol' error.

SHA-1: cce66ae
- add some basic documentation to the generated parser for easier maintainability / usability of the generated code.

SHA-1: 872b540
- lexer.unput(): this.yyleng got out of sync with this.yytext.length as it was not updated after the location range has been updated using its previous value

SHA-1: 538e4fa
- lexer run-time: make sure that too many calls to popState() do not nuke the lexer condition stack.

SHA-1: a0e648e
- Merge remote-tracking branch 'remotes/atrniv/master': topState fix, done another way...

SHA-1: 08fee30
- Fixed an error in topState which used to return the penultimate state instead of the last state on the stack.
- removed unused member variable. (_less)

SHA-1: 5c92866
- added support for a 'backtracking' lexer: this is a standard (non-flex) lexer which for each matching regex will invoke the corresponding action code: when this returns a TOKEN (~ truthy value), then that token is produced (so far the behaviour is identical to the regular lexer); when no token is produced, then the context is rewound and the next matching regex is tried instead, until either a token has been produced or the lexer rules set (regex set) has been exhausted, in which case an ERROR exception is thrown (this last bit is identical to the default lexer too).

This behaviour can be controlled in the generated run-time by the options.backtrack_lexer boolean.

SHA-1: 34130aa
- The parser.lex() method has been corrected to correctly support the new lexer code, which will return boolean FALSE when no token was produced (so that .lexer.js() will recurse until a token has been produced by the lexer action code after all) -- I kept the original @zaach recursion in there instead of turning it into a loop as it would rather quickly cause a fatal error in the JavaScript engine when the lexer action code is broken (and never produces a token): replacing this recursion by a loop would hang the lexer more or less indefinitely, making debugging such a situation much harder.
- augmented the lexer condition state access methods to improve robustness (e.g. against overzealous use of popState() in user action code)
- topState() now can produce one of the pushed lexer condition states when a (positive, non-zero) numeric index is passed as a parameter: topState(0) is identical to topState() and produces the currently active lexer condition state, while topState(1) produces the previously active lexer condition state, etc.

SHA-1: 53b6a35
- lexer: corrected the backtracking feature: the user must call the lexer method .reject() to signal that the current lexer rule FAILED to match a suitable token. (This fixes the scenario where a lexer rule is used to skip whitespace: such a rule won't return a token, nor call more() and should still 'succeed'.)
- lexer: added the ._backtrack boolean member variable to track the invocation of reject() in the lexer action code.

SHA-1: 053f899
- corrected the backtrack_lexer option name in the run-time exception when reject() is invoked in the action code inside a non-backtracking lexer
- added lexer unit tests to verify proper backtrack_lexer operation
