### PR TITLE
Fix: unput leaves yytext one character short

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -206,7 +206,7 @@ RegExpLexer.prototype = {
         var lines = ch.split(/(?:\r\n?|\n)/g);
 
         this._input = ch + this._input;
-        this.yytext = this.yytext.substr(0, this.yytext.length - len - 1);
+        this.yytext = this.yytext.substr(0, this.yytext.length - len);
         //this.yyleng -= len;
         this.offset -= len;
         var oldLines = this.match.split(/(?:\r\n?|\n)/g);


### PR DESCRIPTION
This patch landed in jison about a year ago (https://github.com/zaach/jison/pull/135/files) but never made its way to jison-lex. Hence newer versions of jison (that use jison-lex) are broken again.
