### PR TITLE
Simplify simple return statements.

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -7,7 +7,7 @@ var lexParser = require('lex-parser');
 var version = require('./package.json').version;
 
 // expand macros and convert matchers to RegExp's
-function prepareRules(rules, macros, actions, tokens, startConditions, caseless) {
+function prepareRules(rules, macros, actions, tokens, startConditions, caseless, caseHelper) {
     var m,i,k,action,conditions,
         newRules = [];
 
@@ -60,8 +60,13 @@ function prepareRules(rules, macros, actions, tokens, startConditions, caseless)
         if (tokens && action.match(/return '[^']+'/)) {
             action = action.replace(/return '([^']+)'/g, tokenNumberReplacement);
         }
-        actions.push('case ' + i + ':' + action + '\nbreak;');
+        if (/^return (?:'[^\']+'|\d+)$/.test(action))
+          caseHelper.push(i + ':' + action.substr(7));
+        else
+          actions.push('case ' + i + ':' + action + '\nbreak;');
     }
+    actions.push('default:');
+    actions.push('  return $case_helper[$avoiding_name_collisions]');
     actions.push("}");
 
     return newRules;
@@ -100,6 +105,7 @@ function buildActions (dict, tokens) {
     var actions = [dict.actionInclude || '', "var YYSTATE=YY_START;"];
     var tok;
     var toks = {};
+    var caseHelper = [];
 
     for (tok in tokens) {
         toks[tokens[tok]] = tok;
@@ -109,13 +115,15 @@ function buildActions (dict, tokens) {
         dict.rules.push([".", "console.log(yytext);"]);
     }
 
-    this.rules = prepareRules(dict.rules, dict.macros, actions, tokens && toks, this.conditions, this.options["case-insensitive"]);
+    this.rules = prepareRules(dict.rules, dict.macros, actions, tokens && toks, this.conditions, this.options["case-insensitive"], caseHelper);
     var fun = actions.join("\n");
     "yytext yyleng yylineno yylloc".split(' ').forEach(function (yy) {
         fun = fun.replace(new RegExp("\\b(" + yy + ")\\b", "g"), "yy_.$1");
     });
 
-    return "function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {" + fun + "\n}";
+    return "(function($case_helper) { return " +
+           "function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {" + fun + "\n}" +
+           "})({" + caseHelper.join(',') + "})";
 }
 
 function RegExpLexer (dict, input, tokens) {


### PR DESCRIPTION
I noticed a lexer of mine had a lot of the following generated code:

```
switch($avoiding_name_collisions) {
case 0:/* ignore */
case 1:return 13
break;
case 2:return 16
break;
case 3:return 25
break;
case 4:return 278
break;
case 5:return 279
break;
// …
case 120:console.log(yy_.yytext);
break;
}
```

**This pull requests simplifies this generated code into:**

```
switch($avoiding_name_collisions) {
case 0:/* ignore */
break;
case 120:console.log(yy_.yytext);
break;
default:
  return $case_helper[$avoiding_name_collisions]
}
```
