### PR TITLE
Pass command line options to underlying lexer.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,15 +40,15 @@ exports.main = function (opts) {
         var raw = fs.readFileSync(path.normalize(opts.file), 'utf8'),
             name = path.basename((opts.outfile||opts.file)).replace(/\..*$/g,'');
 
-        fs.writeFileSync(opts.outfile||(name + '.js'), processGrammar(raw, name));
+        fs.writeFileSync(opts.outfile||(name + '.js'), processGrammar(raw, name, opts));
     } else {
         readin(function (raw) {
-            console.log(processGrammar(raw));
+            console.log(processGrammar(raw, null, opts));
         });
     }
 };
 
-function processGrammar (file, name) {
+function processGrammar (file, name, opts) {
     var grammar;
     try {
         grammar = lexParser.parse(file);


### PR DESCRIPTION
The jison-lex command line app isn't generating commonjs compatible code.  I tried specifying the module-type option in the command line:

```
jison-lex calculator.lex -t commonjs
```

However I still get generated code that isn't commonjs compatible.  Looking at the jison-lex code it appears the opts object wasn't being passed to the processGrammar function which is why this option was being ignored.  This pull request contains a fix for the issue.
