### PR TITLE
Some performance tweaks

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -307,7 +307,7 @@ RegExpLexer.prototype = {
         }
 
         // Bail from match if string doesn't contain newline nor carriage return
-        if (lines.indexOf('\n') != -1 || lines.indexOf('\r') != -1) {
+        if (match[0].indexOf('\n') != -1 || match[0].indexOf('\r') != -1) {
             lines = match[0].match(/(?:\r\n?|\n).*/g);
         }
         if (lines) {

--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -306,7 +306,10 @@ RegExpLexer.prototype = {
             }
         }
 
-        lines = match[0].match(/(?:\r\n?|\n).*/g);
+        // Bail from match if string doesn't contain newline nor carriage return
+        if (lines.indexOf('\n') != -1 || lines.indexOf('\r') != -1) {
+            lines = match[0].match(/(?:\r\n?|\n).*/g);
+        }
         if (lines) {
             this.yylineno += lines.length;
         }
@@ -357,19 +360,20 @@ RegExpLexer.prototype = {
         var token,
             match,
             tempMatch,
-            index;
+            ruleMatch;
         if (!this._more) {
             this.yytext = '';
             this.match = '';
         }
         var rules = this._currentRules();
-        for (var i = 0; i < rules.length; i++) {
-            tempMatch = this._input.match(this.rules[rules[i]]);
+        for (var i = 0, n = rules.length; i < n; i++) {
+            const rule = rules[i];
+            tempMatch = this._input.match(this.rules[rule]);
             if (tempMatch && (!match || tempMatch[0].length > match[0].length)) {
                 match = tempMatch;
-                index = i;
+                ruleMatch = rule;
                 if (this.options.backtrack_lexer) {
-                    token = this.test_match(tempMatch, rules[i]);
+                    token = this.test_match(tempMatch, rule);
                     if (token !== false) {
                         return token;
                     } else if (this._backtrack) {
@@ -385,7 +389,7 @@ RegExpLexer.prototype = {
             }
         }
         if (match) {
-            token = this.test_match(match, rules[index]);
+            token = this.test_match(match, ruleMatch);
             if (token !== false) {
                 return token;
             }
@@ -405,12 +409,11 @@ RegExpLexer.prototype = {
 
     // return next match that has a token
     lex: function lex () {
-        var r = this.next();
-        if (r) {
-            return r;
-        } else {
-            return this.lex();
+        let r;
+        while (!r) {
+            r = this.next();
         }
+        return r;
     },
 
     // activates a new lexer condition state (pushes the new lexer condition state onto the condition stack)


### PR DESCRIPTION

I'm working on a project where I'm considering using Jison as a parser generator. I've found the following tweaks to the generated parser has given a modest performance improvement. I would like to submit these changes back to you if you want them.

The changes include

- Changing the lex function to be iterative instead of recursive (remove function call overhead)
-  Caching values from array-indexing in the next function. (On profiling code on my end, a vast majority of the time spent parsing is spent in this function, so every little bit has helped)
- Adding an early bail out for a newline regex test if a string doesn't contain a newline or carriage return. This change may be too specific to our grammar: we don't really expect any newlines and so bailing out of this test early is the biggest performance boost for us. Let me know and I can remove it.

 The modified parser passes all the tests on my side, however you're far familiar with the code than I am so please let me know if you have any feedback on these changes.