### PR TITLE
Added yylloc for error hash

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -239,7 +239,8 @@ RegExpLexer.prototype = {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. You can only invoke reject() in the lexer when the lexer is of the backtracking persuasion (options.backtrack_lexer = true).\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno
+                line: this.yylineno,
+                loc: this.yylloc
             });
 
         }
@@ -398,7 +399,8 @@ RegExpLexer.prototype = {
             return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. Unrecognized text.\n' + this.showPosition(), {
                 text: "",
                 token: null,
-                line: this.yylineno
+                line: this.yylineno,
+                loc: this.yylloc
             });
         }
     },


### PR DESCRIPTION
This is necessary, because top level modules using it will need to know where is the lexical error.   

@zaach I hope that you will accept this pull request and publish a new version of this module at npm, because [my project](https://wongjiahau.github.io/Pineapple/) depended on your Jison parser generator.