### PR TITLE
Detect use of Unicode property in pattern and add flag to compiled RegExp

### DIFF
--- a/regexp-lexer.js
+++ b/regexp-lexer.js
@@ -50,7 +50,9 @@ function prepareRules(rules, macros, actions, tokens, startConditions, caseless)
                     m = m.split("{" + k + "}").join('(' + macros[k] + ')');
                 }
             }
-            m = new RegExp("^(?:" + m + ")", caseless ? 'i':'');
+            /* toggledbits 2022-11-04: detect use of Unicode property name in regexp and enable */
+            var unicode = m.match( /\\p\{/i ) ? 'u' : '';
+            m = new RegExp("^(?:" + m + ")", unicode + (caseless ? 'i':''));
         }
         newRules.push(m);
         if (typeof rules[i][1] === 'function') {


### PR DESCRIPTION
In my grammar for [lexpjs](https://github.com/toggledbits/lexpjs) (an expression language I wrote and use in various contexts), I need to allow Unicode characters in identifiers (variable and function names). As presented, jison-lex 0.3.4 does not have support for RegExp Unicode property escapes in patterns in the source grammar. This change detects the use of a Unicode property escape in a pattern and adds the "u" flag to the compilation of the pattern to make them function correctly.

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes